### PR TITLE
Clean up some test failures.

### DIFF
--- a/apps/search/tests/test_serializers.py
+++ b/apps/search/tests/test_serializers.py
@@ -24,7 +24,8 @@ class SerializerTests(ElasticTestCase):
             'slug': 'serializer',
             'tags': ['tag'],
             'operator': 'OR',
-            'group': {'name': 'Group', 'slug': 'group', 'order': 1}})
+            'group': {'name': 'Group', 'slug': 'group', 'order': 1},
+            'shortcut': None})
 
     def test_document_serializer(self):
         doc = DocumentS(DocumentType)

--- a/apps/search/tests/test_views.py
+++ b/apps/search/tests/test_views.py
@@ -38,7 +38,8 @@ class ViewTests(ElasticTestCase):
                       'slug': 'tagged',
                       'tags': ['tagged'],
                       'operator': 'OR',
-                      'group': {'name': 'Group', 'slug': 'group', 'order': 1}
+                      'group': {'name': 'Group', 'slug': 'group', 'order': 1},
+                      'shortcut': None,
                       }])
 
         test_view1 = Test1SearchView.as_view()

--- a/apps/wiki/tests/test_templates.py
+++ b/apps/wiki/tests/test_templates.py
@@ -515,6 +515,7 @@ class NewRevisionTests(TestCaseBase):
         expected_to = [u'sam@example.com']
         expected_subject = u'[MDN] Page "%s" changed by %s' % (self.d.title,
                                                      new_rev.creator)
+        ok_(len(mail.outbox) > 0, "Edit notification email should have been sent.")
         edited_email = mail.outbox[0]
         eq_(expected_subject, edited_email.subject)
         eq_(expected_to, edited_email.to)


### PR DESCRIPTION
This makes a start on fixing the issues in [kuma pull 2528](https://github.com/mozilla/kuma/pull/2528). Still one failure, but now it is a failure rather than an error (and the failing test correctly checks the length of the outbox to produce the failure).
